### PR TITLE
Fix API entrypoint casing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/bot.js",
     "register": "ts-node src/register.ts",
-    "start:api": "ts-node --transpile-only src/api.ts"
+    "start:api": "ts-node --transpile-only src/API.ts"
   },
   "keywords": [],
   "author": "",

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -5,5 +5,5 @@
     "noImplicitAny": false,
     "strictNullChecks": false
   },
-  "include": ["src/api.ts"]
+  "include": ["src/API.ts"]
 }


### PR DESCRIPTION
## Summary
- point start:api script at `src/API.ts`
- compile API using `src/API.ts` entry in tsconfig

## Testing
- `npm run start:api`
- `npx tsc -p tsconfig.api.json` *(fails: Property 'subscribers' is private and only accessible within class 'AudioPlayer')*

------
https://chatgpt.com/codex/tasks/task_e_684edfa7126c832c8ccca775e78cc856