### PR TITLE
Support NP embed without slash interaction

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -645,6 +645,22 @@ async function NowPlayingEmbedHandler(guildId: string, interaction?: import('dis
             message: null,
             interaction: interaction
         });
+    } else {
+        const guild = client.guilds.cache.get(guildId);
+        if (!guild) return;
+
+        const channel = guild.systemChannel || guild.channels.cache.find(c => c.isTextBased());
+        if (!channel || !channel.isTextBased()) return;
+
+        const message = await channel.send({
+            embeds: [embed],
+            components: [row]
+        });
+
+        nowPlayingMessages.set(guildId, {
+            message,
+            interaction: null
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- allow `NowPlayingEmbedHandler` to send a message when no interaction is supplied

## Testing
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684edfcfe944832cbbbf76a5b0b7fc3e