### PR TITLE
Serve Swagger UI

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,295 @@
+openapi: 3.0.0
+info:
+  title: DisTrack API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+paths:
+  /api/login:
+    post:
+      summary: Exchange a Discord OAuth2 code for tokens
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                redirectUri:
+                  type: string
+              required:
+                - code
+                - redirectUri
+      responses:
+        '200':
+          description: OAuth2 tokens returned from Discord
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Missing parameters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '500':
+          description: Failed to exchange code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+  /api/bot/guilds:
+    get:
+      summary: Get guilds the bot is in
+      responses:
+        '200':
+          description: List of guilds
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '500':
+          description: Failed to fetch guilds
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+  /api/status:
+    get:
+      summary: Get status of the bot player
+      responses:
+        '200':
+          description: Current status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  player:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                      connections:
+                        type: array
+                        items:
+                          type: string
+  /api/now-playing/{guildId}:
+    get:
+      summary: Get the currently playing track for a guild
+      parameters:
+        - in: path
+          name: guildId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current track metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrackMetadata'
+        '404':
+          description: No track currently playing
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+  /api/queue/{guildId}:
+    get:
+      summary: Get the current queue for a guild
+      parameters:
+        - in: path
+          name: guildId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Queue information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  tracks:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/QueueItem'
+        '500':
+          description: Failed to process queue data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+  /api/controls/{guildId}/pause:
+    post:
+      summary: Pause playback
+      parameters:
+        - in: path
+          name: guildId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Playback paused
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: Failed to pause playback
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+  /api/controls/{guildId}/resume:
+    post:
+      summary: Resume playback
+      parameters:
+        - in: path
+          name: guildId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Playback resumed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: Failed to resume playback
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+  /api/controls/{guildId}/skip:
+    post:
+      summary: Skip the current track
+      parameters:
+        - in: path
+          name: guildId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Track skipped
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: Failed to skip track
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+  /api/controls/{guildId}/stop:
+    post:
+      summary: Stop playback and clear the queue
+      parameters:
+        - in: path
+          name: guildId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Playback stopped
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: Failed to stop playback
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+components:
+  schemas:
+    TrackMetadata:
+      type: object
+      properties:
+        url:
+          type: string
+        title:
+          type: string
+        artist:
+          type: string
+        duration:
+          type: string
+        requester:
+          type: string
+        thumbnail:
+          type: string
+      required:
+        - url
+        - title
+        - artist
+        - duration
+        - requester
+    QueueItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        author:
+          type: string
+        thumbnail:
+          type: string
+        duration:
+          type: integer
+        url:
+          type: string
+    SuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+      required:
+        - success
+        - message
+    FailureResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+      required:
+        - success
+        - message

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "discord.js": "^14.19.3",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
-        "play-dl": "^1.9.7"
+        "js-yaml": "^4.1.0",
+        "play-dl": "^1.9.7",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.18",
@@ -732,6 +734,13 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -977,6 +986,12 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -1933,6 +1948,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2592,6 +2619,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.24.1.tgz",
+      "integrity": "sha512-ITeWc7CCAfK53u8jnV39UNqStQZjSt+bVYtJHsOEL3vVj/WV9/8HmsF8Ej4oD8r+Xk1HpWyeW/t59r1QNeAcUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tldts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "discord.js": "^14.19.3",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
-    "play-dl": "^1.9.7"
+    "js-yaml": "^4.1.0",
+    "play-dl": "^1.9.7",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.18",

--- a/src/API.ts
+++ b/src/API.ts
@@ -3,6 +3,9 @@ import cors from 'cors';
 import 'dotenv/config';
 import path from 'path';
 import axios from 'axios';
+import swaggerUi from 'swagger-ui-express';
+import fs from 'fs';
+import yaml from 'js-yaml';
 import {
     getPlayerState,
     getCurrentTrack,
@@ -25,10 +28,14 @@ if (!CLIENT_ID || !CLIENT_SECRET || !BOT_TOKEN) {
 const app = express();
 const PORT = process.env.API_PORT || 3000;
 
+// Load OpenAPI spec
+const swaggerPath = path.join(__dirname, '..', 'openapi.yaml');
+const swaggerDocument = yaml.load(fs.readFileSync(swaggerPath, 'utf8')) as object;
+
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(express.static(path.join(__dirname, 'public')));
+app.use('/test', express.static(path.join(__dirname, 'public')));
 
 app.post('/api/login', async (req, res) => {
     const { code, redirectUri } = req.body as { code?: string; redirectUri?: string };
@@ -172,9 +179,9 @@ app.post<{ guildId: string }>('/api/controls/:guildId/stop', (req, res) => {
     }
 });
 
-app.get('/', (req, res) => {
-    res.sendFile(path.join(__dirname, 'public', 'testsite.html'));
-});
+
+// Serve Swagger UI at the API root
+app.use('/', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.listen(PORT, () => {
     console.log(`🚀 API Server running on port ${PORT}`);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,2 @@
+declare module 'swagger-ui-express';
+declare module 'js-yaml';


### PR DESCRIPTION
## Summary
- add `swagger-ui-express` and `js-yaml`
- load `openapi.yaml` and expose Swagger UI at API root
- move test page under `/test`
- add custom module declarations

## Testing
- `npm run build` *(fails: Property 'subscribers' is private)*

------
https://chatgpt.com/codex/tasks/task_e_684ef008de24832c90fd68eba9c6e378