### PR TITLE
Add Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+DISCORD_TOKEN=your_discord_bot_token
+CLIENT_ID=your_oauth_client_id
+CLIENT_SECRET=your_oauth_client_secret
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
+LOG_SKIPPED_TRACKS=false
+API_PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package*.json ./
+COPY openapi.yaml ./
+EXPOSE 3000
+CMD ["node","dist/API.js"]

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@
 
 - `POST /api/login` – Exchange a Discord OAuth2 code for tokens. Requires `code` and `redirectUri` in the request body.
 - `GET /api/bot/guilds` – Returns guilds the bot is in. Requires the bot token via environment variable.
+
+## Docker Compose
+
+1. Copy `.env.example` to `.env` and fill in your Discord and Spotify credentials.
+2. Run `docker-compose up --build` to build and start the API server.
+
+The API will be available on the port specified in `API_PORT` (defaults to 3000).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    environment:
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - CLIENT_ID=${CLIENT_ID}
+      - CLIENT_SECRET=${CLIENT_SECRET}
+      - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID}
+      - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}
+      - SPOTIFY_REFRESH_TOKEN=${SPOTIFY_REFRESH_TOKEN}
+      - LOG_SKIPPED_TRACKS=${LOG_SKIPPED_TRACKS}
+      - API_PORT=${API_PORT}
+    ports:
+      - "${API_PORT:-3000}:3000"


### PR DESCRIPTION
## Summary
- add docker-compose.yml for easier container orchestration
- document compose usage in README
- provide `.env.example` for environment variables

## Testing
- `npm run build`
- `docker-compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501892fef8832c9ddbca9b426f9dd4