### PR TITLE
Fix voice channel detection for API

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -206,7 +206,7 @@ app.post<{ guildId: string }>('/api/queue/:guildId/add', async (req, res) => {
     try {
         const guild = await client.guilds.fetch(guildId);
         const member = await guild.members.fetch(requesterUId);
-        const voiceChannel = member.voice.channel;
+        const voiceChannel = guild.voiceStates.cache.get(requesterUId)?.channel || member.voice.channel;
 
         if (!voiceChannel) {
             res.status(400).json({ success: false, message: 'Requester is not in a voice channel' });


### PR DESCRIPTION
## Summary
- handle member voice states better when calling the API add endpoint

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68502526ca48832c8dc0d75b321f5dcd